### PR TITLE
Fix for reset key fully resetting metronomes

### DIFF
--- a/src/main/java/com/tilemarkermetronome/TileMarkerMetronomeGroup.java
+++ b/src/main/java/com/tilemarkermetronome/TileMarkerMetronomeGroup.java
@@ -49,6 +49,10 @@ public class TileMarkerMetronomeGroup {
         this.isActive = false;
     }
 
+    public void incrementTick() {
+        currentTick++;
+    }
+
     public void setNextColor() {
         currentColor++;
         if (currentColor >= colors.size()) {

--- a/src/main/java/com/tilemarkermetronome/TileMarkerMetronomePlugin.java
+++ b/src/main/java/com/tilemarkermetronome/TileMarkerMetronomePlugin.java
@@ -127,8 +127,8 @@ public class TileMarkerMetronomePlugin extends Plugin implements KeyListener {
         if (group.getAnimationType() == DISABLED) {
             return;
         }
-
-        if (currentTick % group.getTickCounter() == 0) {
+        group.incrementTick();
+        if (group.getCurrentTick() % group.getTickCounter() == 0) {
             group.setNextColor();
         }
     }


### PR DESCRIPTION
Hello, I made a change so the reset key fully resets the groups and doesnt have the first color show up a variable number of ticks.